### PR TITLE
Update test results for changes in ini

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "proto-list": "~1.2.1",
-    "ini": "1"
+    "ini": "^1.3.4"
   },
   "devDependencies": {
     "tap": "0.3.0"

--- a/test/save.js
+++ b/test/save.js
@@ -38,7 +38,7 @@ test('test saving and loading ini files', function (t) {
         .save('jsonfile')
         .on('save', function () {
           t.equal(fs.readFileSync(f1, 'utf8'),
-                  "bloo = jaus\nfoo = zoo\n")
+                  "bloo=jaus\nfoo=zoo\n")
           t.equal(fs.readFileSync(f2, 'utf8'),
                   "{\"oof\":\"ooz\",\"oolb\":\"suaj\"}")
 


### PR DESCRIPTION
Current versions of ini only add whitespace around the equals sign if explicitly asked to do so with the new `whitespace` option.