### PR TITLE
Add ability to declare comments in input JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var ProtoList = require('proto-list')
   , EE = require('events').EventEmitter
   , url = require('url')
   , http = require('http')
+  , stripJsonComments = require('strip-json-comments')
 
 var exports = module.exports = function () {
   var args = [].slice.call(arguments)
@@ -40,7 +41,7 @@ var find = exports.find = function () {
 }
 
 var parse = exports.parse = function (content, file, type) {
-  content = '' + content
+  content = stripJsonComments('' + content)
   // if we don't know what it is, try json and fall back to ini
   // if we know what it is, then it must be that.
   if (!type) {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "url": "https://github.com/dominictarr/config-chain.git"
   },
   "dependencies": {
+    "ini": "^1.3.4",
     "proto-list": "~1.2.1",
-    "ini": "^1.3.4"
+    "strip-json-comments": "^2.0.1"
   },
   "devDependencies": {
     "tap": "0.3.0"

--- a/test/chain-class.js
+++ b/test/chain-class.js
@@ -8,7 +8,9 @@ var iniObj = { 'x.y.z': 'xyz', blaz: 'ini' }
 var fs = require('fs')
 var ini = require('ini')
 
-fs.writeFileSync('/tmp/config-chain-class.json', JSON.stringify(jsonObj))
+var jsonObjWithComments = '// test comment\n' + JSON.stringify(jsonObj)
+
+fs.writeFileSync('/tmp/config-chain-class.json', jsonObjWithComments)
 fs.writeFileSync('/tmp/config-chain-class.ini', ini.stringify(iniObj))
 
 var http = require('http')


### PR DESCRIPTION
This is useful because I find that I often want to put comments in my JSON files, especially in production code.

Currently, I do this:
```
{
  "__my_amazing_comment": "this is a comment saying that the following line is funky",
  "funky-thing": "I am some funky config that should have a comment"
}
```

By allowing stripping comments, this can be better declared.
```
{
  // This is a comment saying that the following line is funky
  "funky-thing": "I am some funky config that should have a comment"
}
```